### PR TITLE
omit the org name in the project name

### DIFF
--- a/pages/naming-your-project.md
+++ b/pages/naming-your-project.md
@@ -11,3 +11,5 @@ To help users find and recognize your project, we recommend using descriptive na
 You should also do a quick search on the web for your project's name to make sure that name isn't already being used by other software or services, even if it's used in a different space, as it can be confusing for new users. It’s also important to check with your communications team before naming a project so that it can be cleared, if need be.
 
 For example, if you were creating a template your coworkers could use to create guides, a good name for the repo might be *guides-template*. Bad names might include *the-unnamed-project-that-makes-it-easy-to-build-stuff*, *temp-latte*, or *guidestar*.
+
+Within the context of GitHub, the name of your project will always be placed alongside its organizational owner's name. So it's unnecessary to combine the two: instead of naming a project *my-organization-foo*, you can simply name it *foo*.


### PR DESCRIPTION
This could be better-phrased, and potentially we just want positive arguments rather than this kind of implied-critique. I've noticed this as an antipattern in a few government & corporate repos.
