### PR TITLE
Add advice for complying with licenses of embedded work to "Making READMEs readable"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,46 @@ This project is in the worldwide [public domain](LICENSE.md). As stated in [CONT
 >dedication. By submitting a pull request, you are agreeing to comply
 >with this waiver of copyright interest.
 
-### How To Create Your Own Guide
+
+### How to run a local copy of this guide
+
+(Instructions adapted from the [18F Documentation Working Group](https://github.com/18F/wg-documentation).)
+
+You will need [Ruby](https://www.ruby-lang.org) ( > version 2.1.5 ). You may
+consider using a Ruby version manager such as
+[rbenv](https://github.com/sstephenson/rbenv) or [rvm](https://rvm.io/) to
+help ensure that Ruby version upgrades don't mean all your
+[gems](https://rubygems.org/) will need to be rebuilt.
+
+On OS X, you can use [Homebrew](http://brew.sh/) to install Ruby in
+`/usr/local/bin`, which may require you to update your `$PATH` environment
+variable:
+
+```shell
+$ brew update
+$ brew install ruby
+```
+
+To serve the site locally:
+
+```shell
+$ git clone git@github.com:18F/open-source-guide.git
+$ cd open-source-guide
+$ ./go init
+$ ./go serve
+```
+
+This will check that your Ruby version is supported, install the [Bundler
+gem](http://bundler.io/) if it is not yet installed, install all the gems
+needed by the template, and launch a running instance on
+`http://localhost:4000/`. (Make sure to include the trailing
+slash! The built-in Jekyll webserver doesn't redirect to it.)
+
+After going through these steps, run `./go` to see a list of available
+commands. The `serve` command is the most common for routine development.
+
+
+### How to create your own guide
 
 This guide is based on the [DOCter template](https://github.com/cfpb/DOCter) created by the
 [Consumer Financial Protection Bureau](http://www.consumerfinance.gov/) (CFPB). Our canonical

--- a/README.md
+++ b/README.md
@@ -33,46 +33,7 @@ This project is in the worldwide [public domain](LICENSE.md). As stated in [CONT
 >dedication. By submitting a pull request, you are agreeing to comply
 >with this waiver of copyright interest.
 
-
-### How to run a local copy of this guide
-
-(Instructions adapted from the [18F Documentation Working Group](https://github.com/18F/wg-documentation).)
-
-You will need [Ruby](https://www.ruby-lang.org) ( > version 2.1.5 ). You may
-consider using a Ruby version manager such as
-[rbenv](https://github.com/sstephenson/rbenv) or [rvm](https://rvm.io/) to
-help ensure that Ruby version upgrades don't mean all your
-[gems](https://rubygems.org/) will need to be rebuilt.
-
-On OS X, you can use [Homebrew](http://brew.sh/) to install Ruby in
-`/usr/local/bin`, which may require you to update your `$PATH` environment
-variable:
-
-```shell
-$ brew update
-$ brew install ruby
-```
-
-To serve the site locally:
-
-```shell
-$ git clone git@github.com:18F/open-source-guide.git
-$ cd open-source-guide
-$ ./go init
-$ ./go serve
-```
-
-This will check that your Ruby version is supported, install the [Bundler
-gem](http://bundler.io/) if it is not yet installed, install all the gems
-needed by the template, and launch a running instance on
-`http://localhost:4000/`. (Make sure to include the trailing
-slash! The built-in Jekyll webserver doesn't redirect to it.)
-
-After going through these steps, run `./go` to see a list of available
-commands. The `serve` command is the most common for routine development.
-
-
-### How to create your own guide
+### How To Create Your Own Guide
 
 This guide is based on the [DOCter template](https://github.com/cfpb/DOCter) created by the
 [Consumer Financial Protection Bureau](http://www.consumerfinance.gov/) (CFPB). Our canonical

--- a/pages/making-readmes-readable.md
+++ b/pages/making-readmes-readable.md
@@ -57,7 +57,7 @@ We [explicitly welcome outside contributors](https://github.com/18F/open-source-
 
 **Example:** The README for Midas contains a section called “[How you can help.](https://github.com/18f/midas#how-you-can-help)” What we really like about this section is that it doesn’t assume helpers are developers and lists ways for lots of different people to contribute. (Our [guide to welcoming non-coders to hackathons](https://18f.gsa.gov/2015/04/03/how-to-welcome-new-coders-to-a-civic-hackathon/) also contains many suggestions for ways to involve people with different skillsets.)
 
-We also recommend reading Midas’ [Contributor’s Guide](https://github.com/18F/midas/blob/devel/CONTRIBUTING.md), which orients new dev contributors and tells them the best ways to communicate with Midas’ dev team.
+We also recommend reading Midas’ [Contributor’s Guide](https://github.com/18F/midas/blob/dev/CONTRIBUTING.md), which orients new dev contributors and tells them the best ways to communicate with Midas’ dev team.
 
 ## List the licensing information for your project.
 

--- a/pages/making-readmes-readable.md
+++ b/pages/making-readmes-readable.md
@@ -63,6 +63,16 @@ We also recommend reading Midas’ [Contributor’s Guide](https://github.com/18
 
 This part of the repo should answer the question: **What is the license for this project?** All 18F projects are developed in the international public domain whenever possible and contain a [LICENSE.md](https://github.com/18F/open-source-policy/blob/master/LICENSE.md) document, as well as a paragraph at the end of each README which contains information about the public domain. We post this information [in the README](https://github.com/18F/18f.gsa.gov#public-domain), so that users know the code can be adapted and reused, and so they can easily see this information instead of going to a second site.
 
+### Include credit and licenses for embedded resources
+
+If your project includes code or other resources (such as icons, fonts, or photos) from outside sources, your project's license description (in the README, LICENSE, and CONTRIBUTING files) should credit the authors of that work and include their license information.
+
+It's polite to give full credit when reusing work, even if not legally required by the work's license, and this helps users who want to find the original source and use it.
+
+We also have a legal responsibility to respect the licenses of work we use. When adapting or embedding outside work, check its license for instructions for complying with that license.
+
+For example, see ["Licenses and attribution" in the U.S. Web Design Standards README](https://github.com/18F/web-design-standards#licenses-and-attribution). It starts with "A few parts of this project are not in the public domain", to prevent accidentally implying that all the project's files are in the public domain. It lists exceptions in this format: "The file *filename* is from *project name*, by *name of author* [or copyright *name of author*], under *name of license*." Then it has a section titled "The rest of this project is in the public domain", with the typical license information we put in READMEs. The project's [CONTRIBUTING file](https://github.com/18F/web-design-standards/blob/18f-pages-staging/CONTRIBUTING.md) includes the same sections. The [LICENSE file](https://github.com/18F/web-design-standards/blob/18f-pages-staging/LICENSE.md) has the same sections again, plus the full license text for some embedded works and our standard LICENSE information.
+
 ## List the contact information for your team as well as where to ask questions.
 
 This part of the repo should make it easy for users to get in touch with the team developing the project. This is also where you should list any listservs, chat programs, or social media groups that have been created to keep contributors informed.


### PR DESCRIPTION
Also fixed an outdated URL on that page.
