### PR TITLE
Remove `./go init` from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ To serve the site locally:
 ```shell
 $ git clone git@github.com:18F/open-source-guide.git
 $ cd open-source-guide
-$ ./go init
 $ ./go serve
 ```
 


### PR DESCRIPTION
With the new `./go` script style, `./go init` is no longer necessary for this guide.

Noticed this when checking out #22.

cc: @brittag @afeld @melodykramer 
